### PR TITLE
Specify Epoll as External

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
             entry: ["electron/main.ts", "electron/preload.ts"],
             vite: {
                 build: {
-                    outDir: "dist/electron"
+                    outDir: "dist/electron",
+                    rollupOptions: {
+                        external: ["epoll"]
+                    }
                 }
             }
         }),


### PR DESCRIPTION
As specified in the [vite-plugin-electron docs](https://github.com/electron-vite/vite-plugin-electron#be-aware), we might need to manually specify certain native C/C++ modules because rollup will not build them properly. This is now done for epoll, which is the native library used by gpio to control the Pi GPIO. This is important as it makes the Garage buttons work.